### PR TITLE
Patch request info

### DIFF
--- a/pyband/data.py
+++ b/pyband/data.py
@@ -80,8 +80,8 @@ class Request(object):
 @dataclass
 class RawReport(object):
     exit_code: int
+    data: Optional[bytes]
     external_id: int = 0
-    data: Optional[bytes] = b""
 
 
 @dataclass
@@ -101,9 +101,9 @@ class Result(object):
     resolve_status: str
     request_id: int
     ans_count: int
+    result: Optional[bytes]
     client_id: str = ""
     calldata: bytes = b""
-    result: bytes = b""
 
 
 @dataclass

--- a/pyband/data.py
+++ b/pyband/data.py
@@ -57,10 +57,12 @@ class RawRequest(object):
     external_id: int = 0
     calldata: bytes = b""
 
+
 @dataclass
 class IBCChannel(object):
     port_id: str
     channel_id: str
+
 
 @dataclass
 class Request(object):
@@ -79,7 +81,7 @@ class Request(object):
 class RawReport(object):
     exit_code: int
     external_id: int = 0
-    data: bytes = b""
+    data: Optional[bytes] = b""
 
 
 @dataclass


### PR DESCRIPTION
Use optional for nullable fields
dacite fail to parse json to dataclass when our class and data look like
```python
@dataclass
class Bar:
    foo: int = 0
```
Would not work with(But work in case that foo is not appear)
```json
{
    "foo": null
}
```