### PR TITLE
Bump github action version to fix test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,23 +11,23 @@ jobs:
 
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache Poetry cache
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pypoetry
           key: poetry-cache-${{ runner.os }}-${{ matrix.python-version }}
 
       # virtualenv cache should depends on OS, Python version and `poetry.lock` (and optionally workflow files).
       - name: Cache Packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.local
           key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,10 +10,11 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - name: Install OpenSSL
+      - name: Install OpenSSL with ripemd160 support
         run: |
           sudo apt-get update
           sudo apt-get install -y libssl-dev
+          sudo ln -s /usr/lib/x86_64-linux-gnu/openssl-1.0.0/engines/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
 
       - name: Code Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,19 +3,13 @@ on: pull_request
 
 jobs:
   pyband-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
-      - name: Install OpenSSL with ripemd160 support
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev
-          sudo ln -s /usr/lib/x86_64-linux-gnu/openssl-1.0.0/engines/libcrypto.so /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
-
       - name: Code Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,11 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
+      - name: Install OpenSSL
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libssl-dev
+
       - name: Code Checkout
         uses: actions/checkout@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ license = "MIT"
 name = "pyband"
 readme = "README.md"
 repository = "https://github.com/bandprotocol/pyband"
-version = "0.3.4"
+version = "0.3.5"
 
 [tool.poetry.dependencies]
 bech32 = "1.2.0"


### PR DESCRIPTION
- Bump Github action dependency version
- Downgrade ubuntu version 20.04 because there is an issue in ubuntu 22.04 with ripemd160 (ValueError: unsupported hash type ripemd160).

Next action:
- Fix the code to support ubuntu 22.04